### PR TITLE
fixing the name of codecentric. The name is a brand and always appear…

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -252,7 +252,7 @@ googleAnalytics = "UA-60791139-1"
 			link = "http://www.arolla.fr"
 
 		[[params.sponsor]]
-			name = "Codecentric"
+			name = "codecentric"
 			logo = "codecentric-square.png"
 			link = "http://www.codecentric.de"
 


### PR DESCRIPTION
…s with a non-capital “c” at the beginning