### PR TITLE
Add AgileCrete.org to list of partner (un)conferences

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -240,6 +240,15 @@ googleAnalytics = "UA-60791139-1"
 				["fa-link", "http://itakeunconf.com"]
 			]
 
+		[[params.team.members]]
+			img = "agileCrete.png"
+			name = "AgileCrete Unconference"
+			position = "Crete, Greece"
+			social = [
+				["fa-twitter", "https://twitter.com/AgileCrete"],
+				["fa-link", "https://agilecrete.org"]
+			]
+
 
 	# Sponsor section
 	[params.sponsors]


### PR DESCRIPTION
https://agileCrete.org has a strong focus on software craft and very much considers itself a part of the SoCraTes events (and definitely not a "conference on Agile" ; )  )